### PR TITLE
Added None checks for image transformation calls

### DIFF
--- a/classification/dataset.py
+++ b/classification/dataset.py
@@ -101,7 +101,9 @@ class MsgPackIterableDatasetMultiTargetWithDynLabels(torch.utils.data.IterableDa
             img = torchvision.transforms.Resize(320)(img)
 
         # apply all user specified image transformations
-        img = self.transformation(img)
+        if self.transformation is not None:
+            img = self.transformation(img)
+
         if self.meta_path is None:
             return img, x["target"]
         else:

--- a/filter_by_downloaded_images.py
+++ b/filter_by_downloaded_images.py
@@ -108,7 +108,8 @@ class MsgPackIterableMetaDataset(torch.utils.data.IterableDataset):
                 img = torchvision.transforms.Resize(320)(img)
 
             # apply all user specified image transformations
-            img = self.transformation(img)
+            if self.transformation is not None:
+                img = self.transformation(img)
 
         _id = x[self.key_img_id].decode("utf-8")
         meta = self.meta.loc[_id].to_dict()

--- a/msgpack_viewer.py
+++ b/msgpack_viewer.py
@@ -74,7 +74,8 @@ class MsgPackIterableDataset(torch.utils.data.IterableDataset):
             img = torchvision.transforms.Resize(320)(img)
 
         # apply all user specified image transformations
-        img = self.transformation(img)
+        if self.transformation is not None:
+            img = self.transformation(img)
         
         _id = x[self.key_img_id].decode("utf-8")
         return img, _id


### PR DESCRIPTION
In these three instances, transformation is set to None when initialized, and it is not checked before it is called. This was not an issue when trying to reproduce the results, but it could become an issue for anyone modifying the code.